### PR TITLE
Added feature to print the content of the objetcs

### DIFF
--- a/angular-ny-logger.js
+++ b/angular-ny-logger.js
@@ -1,4 +1,5 @@
 angular.module('ny.logger', []).provider('Logger', [function () {
+
     var isEnabled = true;
     this.enabled = function(_isEnabled) {
         isEnabled = !!_isEnabled;
@@ -53,7 +54,8 @@ angular.module('ny.logger', []).provider('Logger', [function () {
                         break;
                 }
 
-                $log[originalFn].call(null, Logger.supplant(message, supplantData));
+                var params = (isObject(supplantData)) ? [message, supplantData] : [Logger.supplant(message, supplantData)];
+                $log[originalFn].apply(null, params);
             },
             log: function() {
                 this._log('log', arguments);
@@ -73,4 +75,8 @@ angular.module('ny.logger', []).provider('Logger', [function () {
         };
         return Logger;
     }];
+
+    function isObject(element){
+        return (element.constructor.toString().indexOf("Object") > -1);
+    }
 }]);

--- a/angular-ny-logger.js
+++ b/angular-ny-logger.js
@@ -77,6 +77,7 @@ angular.module('ny.logger', []).provider('Logger', [function () {
     }];
 
     function isObject(element){
-        return (element.constructor.toString().indexOf("Object") > -1);
+        var elemStr = ( !angular.isUndefined(element) && !angular.isUndefined(element.constructor) ) ? element.constructor.toString() : "";
+        return (elemStr.indexOf("Object") > -1);
     }
 }]);


### PR DESCRIPTION
Nice feature added to this useful lib.

Example:

var myObj = {
                'key1' : 'value1',
                'key2' : 'value2',
                'key3' : {
                    'key3_1' : 'value3_1',
                    'key3_2' : 'value3_2'
                },
                'key4' : 'value4',
                'key5' : 'value5',
                'key6' : 'value6',
                'key7' : 'value7'
            };
logger.debug('myObj: ',myObj);
