### PR TITLE
Added functionality to append objects to the original log message

### DIFF
--- a/angular-ny-logger.js
+++ b/angular-ny-logger.js
@@ -21,9 +21,9 @@ angular.module('ny.logger', []).provider('Logger', [function () {
         };
         Logger.getFormattedTimestamp = function(date) {
            return Logger.supplant('{0}:{1}:{2}:{3}', [
-                date.getHours(),
-                date.getMinutes(),
-                date.getSeconds(),
+                date.getHours() < 10 ? "0" + date.getHours() : date.getHours(),
+                date.getMinutes() < 10 ? "0" + date.getMinutes() : date.getMinutes(),
+                date.getSeconds() < 10 ? "0" + date.getSeconds() : date.getSeconds(),
                 date.getMilliseconds()
             ]);
         };

--- a/angular-ny-logger.js
+++ b/angular-ny-logger.js
@@ -32,7 +32,28 @@ angular.module('ny.logger', []).provider('Logger', [function () {
                 if (!isEnabled) {
                     return;
                 }
-                
+
+                var objects = [];
+
+                if (args[args.length - 1] !== undefined) {
+                    // supplants array
+                    var supplantsArray = args[args.length - 1];
+
+                    // filter out all objects
+                    for (var i = supplantsArray.length - 1; i >= 0; i--) {
+                        var candidate = supplantsArray[i];
+                        if (typeof candidate === 'object') {
+                            objects.push(candidate);
+
+                            // remove object from supplants array
+                            var candidateIndex = supplantsArray.indexOf(candidate);
+                            if (candidateIndex > -1) {
+                                supplantsArray.splice(candidateIndex, 1);
+                            }
+                        }
+                    }
+                }
+
                 var now  = Logger.getFormattedTimestamp(new Date());
                 var message = '', supplantData = [];
                 switch (args.length) {
@@ -53,7 +74,11 @@ angular.module('ny.logger', []).provider('Logger', [function () {
                         break;
                 }
 
-                $log[originalFn].call(null, Logger.supplant(message, supplantData));
+                // prepare arguments list for log call as array with log message
+                var formattedMessage = [ Logger.supplant(message, supplantData) ];
+
+                // call the original $log with all arguments and append all objects that should be logged
+                $log[originalFn].apply(null, formattedMessage.concat(objects));
             },
             log: function() {
                 this._log('log', arguments);


### PR DESCRIPTION
Objects can be added to log messages and hours, minutes and seconds less than 10 are printed with prepended zeros.

Add objects to the supplant array and they will be logged as well as long as they are out of the index of the curly braces:

`logger.info('this object caused trouble at line {0}:', ['18', {'foo': 'bar'}]);`
